### PR TITLE
Remove legacy build scripts* and update to htmlcompressor 1.6.1**

### DIFF
--- a/build-local.bat
+++ b/build-local.bat
@@ -1,1 +1,0 @@
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar install

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar install

--- a/build-release.bat
+++ b/build-release.bat
@@ -1,1 +1,0 @@
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar release:clean release:prepare release:perform

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar release:clean release:prepare release:perform

--- a/build-snapshot.bat
+++ b/build-snapshot.bat
@@ -1,1 +1,0 @@
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar deploy

--- a/build-snapshot.sh
+++ b/build-snapshot.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar deploy

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,0 @@
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mvn clean package javadoc:jar javadoc:test-jar source:jar source:test-jar site:jar

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
   <!-- ====================================================================== -->
   <dependencies>
     <dependency>
-      <groupId>com.googlecode.htmlcompressor</groupId>
+      <groupId>com.github.hazendaz</groupId>
       <artifactId>htmlcompressor</artifactId>
-      <version>1.5.2</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.javascript</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.github.hazendaz</groupId>
       <artifactId>htmlcompressor</artifactId>
-      <version>1.6.0</version>
+      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.javascript</groupId>


### PR DESCRIPTION
* These scripts serve no real purpose in helping the build.  These are copied from htmlcompressor which I've deleted there too.  The release will handle what needs addressed.  This is further tied into travis-ci and if we want to go a bit further we can setup auto snapshot releases.

** I've taken over ownership of htmlcompressor.