### PR TITLE
Mark mojos as threadSafe

### DIFF
--- a/src/main/java/com/tunyk/mvn/plugins/htmlcompressor/HtmlCompressorMojo.java
+++ b/src/main/java/com/tunyk/mvn/plugins/htmlcompressor/HtmlCompressorMojo.java
@@ -44,7 +44,7 @@ import java.util.regex.PatternSyntaxException;
 /**
  * Compress HTML files
  */
-@Mojo(name = "html", defaultPhase = LifecyclePhase.COMPILE, requiresProject = false)
+@Mojo(name = "html", defaultPhase = LifecyclePhase.COMPILE, requiresProject = false, threadSafe = true)
 public class HtmlCompressorMojo extends AbstractMojo {
 
     /**

--- a/src/main/java/com/tunyk/mvn/plugins/htmlcompressor/XmlCompressorMojo.java
+++ b/src/main/java/com/tunyk/mvn/plugins/htmlcompressor/XmlCompressorMojo.java
@@ -27,7 +27,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 /**
  * Compress XML files
  */
-@Mojo(name = "xml", defaultPhase = LifecyclePhase.COMPILE, requiresProject = false)
+@Mojo(name = "xml", defaultPhase = LifecyclePhase.COMPILE, requiresProject = false, threadSafe = true)
 public class XmlCompressorMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
**Motivation**

I get following message when launch parallel built with -T flag

[INFO] --------------------------------[ pom ]---------------------------------
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe:
[WARNING] com.github.hazendaz.maven:htmlcompressor-maven-plugin:1.5.2
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************


**Summary**

This plugin is based on htmlcompressor lib that is thread-safe. I don't find any other reason the plugin to be not thread-safe as well. So I think it can be marked that way.